### PR TITLE
added rename/format(spi,qspi) to littlefs

### DIFF
--- a/src/LittleFS.cpp
+++ b/src/LittleFS.cpp
@@ -101,6 +101,25 @@ bool LittleFS_SPIFlash::begin(uint8_t cspin, SPIClass &spiport)
 	return true;
 }
 
+FLASHMEM
+bool LittleFS_SPIFlash::format()
+{
+
+	Serial.println("attemping to format existing media");
+	if (lfs_format(&lfs, &config) < 0) {
+		Serial.println("format failed :(");
+		return false;
+	}
+		Serial.println("attemping to mount freshly formatted media");
+		if (lfs_mount(&lfs, &config) < 0) {
+			Serial.println("mount after format failed :(");
+			return false;
+		}
+	Serial.println("success");
+	return true;
+}
+
+
 
 static void make_command_and_address(uint8_t *buf, uint8_t cmd, uint32_t addr, uint8_t addrbits)
 {
@@ -205,7 +224,7 @@ int LittleFS_SPIFlash::wait(uint32_t microseconds)
 		if (usec > microseconds) return LFS_ERR_IO; // timeout
 		yield();
 	}
-	Serial.printf("  waited %u us\n", (unsigned int)usec);
+	//Serial.printf("  waited %u us\n", (unsigned int)usec);
 	return 0; // success
 }
 
@@ -396,6 +415,25 @@ bool LittleFS_QSPIFlash::begin()
 	Serial.println("success");
 	return true;
 }
+
+FLASHMEM
+bool LittleFS_QSPIFlash::format()
+{
+
+	Serial.println("attemping to format existing media");
+	if (lfs_format(&lfs, &config) < 0) {
+		Serial.println("format failed :(");
+		return false;
+	}
+		Serial.println("attemping to mount freshly formatted media");
+		if (lfs_mount(&lfs, &config) < 0) {
+			Serial.println("mount after format failed :(");
+			return false;
+		}
+	Serial.println("success");
+	return true;
+}
+
 
 
 int LittleFS_QSPIFlash::read(lfs_block_t block, lfs_off_t offset, void *buf, lfs_size_t size)

--- a/src/LittleFS.h
+++ b/src/LittleFS.h
@@ -205,6 +205,13 @@ public:
 		if (lfs_mkdir(&lfs, filepath) < 0) return false;
 		return true;
 	}
+	
+	bool rename(const char *oldfilepath, const char *newfilepath) {
+		if (!configured) return false;
+		if (lfs_rename(&lfs, oldfilepath, newfilepath) < 0) return false;
+		return true;
+	}
+	
 	bool remove(const char *filepath) {
 		if (!configured) return false;
 		if (lfs_remove(&lfs, filepath) < 0) return false;
@@ -297,6 +304,7 @@ public:
 		port = nullptr;
 	}
 	bool begin(uint8_t cspin, SPIClass &spiport=SPI);
+	bool format();
 private:
 	int read(lfs_block_t block, lfs_off_t offset, void *buf, lfs_size_t size);
 	int prog(lfs_block_t block, lfs_off_t offset, const void *buf, lfs_size_t size);
@@ -333,6 +341,7 @@ class LittleFS_QSPIFlash : public LittleFS
 public:
 	LittleFS_QSPIFlash() { }
 	bool begin();
+	bool format();
 private:
 	int read(lfs_block_t block, lfs_off_t offset, void *buf, lfs_size_t size);
 	int prog(lfs_block_t block, lfs_off_t offset, const void *buf, lfs_size_t size);
@@ -365,7 +374,6 @@ class LittleFS_QSPIFlash : public LittleFS
 public:
 	LittleFS_QSPIFlash() { }
 	bool begin() { return false; }
-};
 #endif
 
 


### PR DESCRIPTION
Paul
Know you are busy as heck so I went ahead and tried adding in format(spi and qspi) and rename commands for LittleFs.  Looks like they are working from my limited testing so far.  Seems to be working with MTP for LittleFS as well.

Mike