### PR TITLE
Fix potential buffer overflows

### DIFF
--- a/src/LittleFS.h
+++ b/src/LittleFS.h
@@ -33,14 +33,14 @@ public:
 		lfs = lfsin;
 		file = filein;
 		dir = nullptr;
-		strcpy(fullpath, name); // TODO: prevent buffer overflow
+		strncpy(fullpath, name, 128);
 		//Serial.printf("  LittleFSFile ctor (file), this=%x\n", (int)this);
 	}
 	LittleFSFile(lfs_t *lfsin, lfs_dir_t *dirin, const char *name) {
 		lfs = lfsin;
 		dir = dirin;
 		file = nullptr;
-		strcpy(fullpath, name); // TODO: prevent buffer overflow
+		strncpy(fullpath, name, 128);
 		//Serial.printf("  LittleFSFile ctor (dir), this=%x\n", (int)this);
 	}
 	virtual ~LittleFSFile() {
@@ -138,8 +138,7 @@ public:
 		} while (strcmp(info.name, ".") == 0 || strcmp(info.name, "..") == 0);
 		//Serial.printf("  next name = \"%s\"\n", info.name);
 		char pathname[128];
-		// TODO: prevent buffer overflow
-		strcpy(pathname, fullpath);
+		strncpy(pathname, fullpath, 128);
 		strcat(pathname, "/"); // TODO: do only if fullpath doesn't end with '/'
 		strcat(pathname, info.name);
 		if (info.type == LFS_TYPE_REG) {

--- a/src/LittleFS.h
+++ b/src/LittleFS.h
@@ -33,14 +33,14 @@ public:
 		lfs = lfsin;
 		file = filein;
 		dir = nullptr;
-		strncpy(fullpath, name, 128);
+		strncpy(fullpath, name, sizeof(fullpath));
 		//Serial.printf("  LittleFSFile ctor (file), this=%x\n", (int)this);
 	}
 	LittleFSFile(lfs_t *lfsin, lfs_dir_t *dirin, const char *name) {
 		lfs = lfsin;
 		dir = dirin;
 		file = nullptr;
-		strncpy(fullpath, name, 128);
+		strncpy(fullpath, name, sizeof(fullpath));
 		//Serial.printf("  LittleFSFile ctor (dir), this=%x\n", (int)this);
 	}
 	virtual ~LittleFSFile() {
@@ -138,7 +138,7 @@ public:
 		} while (strcmp(info.name, ".") == 0 || strcmp(info.name, "..") == 0);
 		//Serial.printf("  next name = \"%s\"\n", info.name);
 		char pathname[128];
-		strncpy(pathname, fullpath, 128);
+		strncpy(pathname, fullpath, sizeof(pathname));
 		strcat(pathname, "/"); // TODO: do only if fullpath doesn't end with '/'
 		strcat(pathname, info.name);
 		if (info.type == LFS_TYPE_REG) {


### PR DESCRIPTION
I don't have anything I can actually test these changes with, but logically using `strncpy` with the size of the destination buffer as the `count` argument should prevent buffer overflows.