### PR TITLE
Added QSPI Initialize Function for Total erase

### DIFF
--- a/src/LittleFS.cpp
+++ b/src/LittleFS.cpp
@@ -501,7 +501,7 @@ int LittleFS_QSPIFlash::erase(lfs_block_t block)
 }
 
 
-void LittleFS_QSPIFlash::initialize() {
+bool LittleFS_QSPIFlash::initialize() {
   if(lfs_unmount(&lfs) < 0) {
 	  Serial.println("Can not unmount device");
   } else {

--- a/src/LittleFS.h
+++ b/src/LittleFS.h
@@ -383,6 +383,7 @@ class LittleFS_QSPIFlash : public LittleFS
 public:
 	LittleFS_QSPIFlash() { }
 	bool begin();
+	void initialize();
 private:
 	int read(lfs_block_t block, lfs_off_t offset, void *buf, lfs_size_t size);
 	int prog(lfs_block_t block, lfs_off_t offset, const void *buf, lfs_size_t size);

--- a/src/LittleFS.h
+++ b/src/LittleFS.h
@@ -383,7 +383,7 @@ class LittleFS_QSPIFlash : public LittleFS
 public:
 	LittleFS_QSPIFlash() { }
 	bool begin();
-	void initialize();
+	bool initialize();
 private:
 	int read(lfs_block_t block, lfs_off_t offset, void *buf, lfs_size_t size);
 	int prog(lfs_block_t block, lfs_off_t offset, const void *buf, lfs_size_t size);


### PR DESCRIPTION
Paul - @Defragster 

Added a new function for the QSPIFlash, initialize, that does a full media format, guess see this and above: https://forum.pjrc.com/threads/58033-LittleFS-port-to-Teensy-SPIFlash?p=259855&viewfull=1#post259855

Its based on FrankB's eraseChip function and what I also used in spiffs in addition to the basic format command.

You may want to move the LUT60 up to the begin function since its not used anywhere else it seems.  