### PR TITLE
Limit progressChar SPEW chars - assuming .block_count is a large number

### DIFF
--- a/src/LittleFS.cpp
+++ b/src/LittleFS.cpp
@@ -172,9 +172,10 @@ bool LittleFS::lowLevelFormat(char progressChar)
 		lfs_unmount(&lfs);
 		mounted = false;
 	}
+	int ii=config.block_count/40;
 	void *buffer = malloc(config.read_size);
 	for (unsigned int block=0; block < config.block_count; block++) {
-		if (progressChar) Serial.write(progressChar);
+		if (progressChar && (0 == block%ii) ) Serial.write(progressChar);
 		if (!blockIsBlank(&config, block, buffer)) {
 			(*config.erase)(&config, block);
 		}

--- a/src/LittleFS.cpp
+++ b/src/LittleFS.cpp
@@ -172,7 +172,7 @@ bool LittleFS::lowLevelFormat(char progressChar)
 		lfs_unmount(&lfs);
 		mounted = false;
 	}
-	int ii=config.block_count/40;
+	int ii=config.block_count/120;
 	void *buffer = malloc(config.read_size);
 	for (unsigned int block=0; block < config.block_count; block++) {
 		if (progressChar && (0 == block%ii) ) Serial.write(progressChar);


### PR DESCRIPTION
Only print the progressChar every 1/40th of the media