### PR TITLE
after LLformat check skip first LittleFS preFormat

### DIFF
--- a/src/LittleFS.h
+++ b/src/LittleFS.h
@@ -197,10 +197,14 @@ public:
 	LittleFS() {
 		configured = false;
 		mounted = false;
+		checkformat = false;
 		config.context = nullptr;
 	}
 	bool quickFormat();
 	bool lowLevelFormat(char progressChar=0);
+	void checkFormat(bool readCheck) {
+		checkformat = readCheck;
+	}
 	File open(const char *filepath, uint8_t mode = FILE_READ) {
 		//Serial.println("LittleFS open");
 		if (!mounted) return File();
@@ -275,6 +279,7 @@ public:
 protected:
 	bool configured;
 	bool mounted;
+	bool checkformat;
 	lfs_t lfs;
 	lfs_config config;
 };
@@ -323,6 +328,7 @@ public:
 		if (lfs_mount(&lfs, &config) < 0) return false;
 		//Serial.println("mounted atfer format");
 		mounted = true;
+		checkformat = false;
 		return true;
 	}
 private:


### PR DESCRIPTION
For test results see https://forum.pjrc.com/threads/58033-LittleFS-port-to-Teensy-SPIFlash?p=260718&viewfull=1#post260718

QSPI:
108.1 secs :: lowLevelFormat
 27.5  secs :: Big File write > 16728000 Bytes << CLEAN MEDIA - no pre-format
135.6 secs :: Big File write > 16728000 Bytes << DIRTY MEDIA

SPI:
348.4 secs :: lowLevelFormat
 36.9  secs :: Big File write > 16728000 Bytes << CLEAN MEDIA - no pre-format
384.6 secs :: Big File write > 16728000 Bytes << DIRTY MEDIA