### PR TITLE
Low Level format optional choose where the characters print

### DIFF
--- a/src/LittleFS.cpp
+++ b/src/LittleFS.cpp
@@ -320,7 +320,7 @@ uint32_t LittleFS::formatUnused(uint32_t blockCnt, uint32_t blockStart) {
 }
 
 FLASHMEM
-bool LittleFS::lowLevelFormat(char progressChar)
+bool LittleFS::lowLevelFormat(char progressChar, Print* pr)
 {
 	if (!configured) return false;
 	if (mounted) {
@@ -330,13 +330,13 @@ bool LittleFS::lowLevelFormat(char progressChar)
 	int ii=config.block_count/120;
 	void *buffer = malloc(config.read_size);
 	for (unsigned int block=0; block < config.block_count; block++) {
-		if (progressChar && (0 == block%ii) ) Serial.write(progressChar);
+		if (pr && progressChar && (0 == block%ii) ) pr->write(progressChar);
 		if (!blockIsBlank(&config, block, buffer)) {
 			(*config.erase)(&config, block);
 		}
 	}
 	free(buffer);
-	if (progressChar) Serial.println();
+	if (pr && progressChar) pr->println();
 	return quickFormat();
 }
 

--- a/src/LittleFS.h
+++ b/src/LittleFS.h
@@ -199,7 +199,7 @@ public:
 		config.context = nullptr;
 	}
 	bool quickFormat();
-	bool lowLevelFormat(char progressChar=0);
+	bool lowLevelFormat(char progressChar=0, Print* pr=&Serial);
 	uint32_t formatUnused(uint32_t blockCnt, uint32_t blockStart);
 	File open(const char *filepath, uint8_t mode = FILE_READ) {
 		//Serial.println("LittleFS open");

--- a/src/LittleFS_NAND.cpp
+++ b/src/LittleFS_NAND.cpp
@@ -673,6 +673,7 @@ uint8_t LittleFS_SPINAND::addBBLUT(uint32_t block_address)
 	Serial.printf("First Open Entry: %d\n", firstOpenEntry);
 	
 	//Write BBLUT with next sequential block
+	#ifdef LATER
 	uint8_t cmd[5];
 	
 	uint16_t pba, lba;
@@ -691,7 +692,7 @@ uint8_t LittleFS_SPINAND::addBBLUT(uint32_t block_address)
 	//port->transfer(cmd, 5);
     //digitalWrite(pin, HIGH);
     //port->endTransaction();
-	
+	#endif
 	wait(progtime);
 	
   }
@@ -719,11 +720,11 @@ void LittleFS_SPINAND::deviceReset()
 
 }
 
-bool LittleFS_SPINAND::lowLevelFormat(char progressChar)
+bool LittleFS_SPINAND::lowLevelFormat(char progressChar, Print* pr)
 {
 	uint32_t eraseAddr;
 	bool val;
-	val = LittleFS::lowLevelFormat(progressChar);
+	val = LittleFS::lowLevelFormat(progressChar, pr);
 	
 	for(uint16_t blocks = 0; blocks < reservedBBMBlocks; blocks++) {
 		eraseAddr = (config.block_count + blocks) * config.block_size;
@@ -1410,7 +1411,7 @@ uint8_t LittleFS_QPINAND::addBBLUT(uint32_t block_address)
 	//lba = LINEAR_TO_BLOCK((firstOpenEntry+1)*config.block_size);
 	lba = LINEAR_TO_BLOCK((firstOpenEntry+1)*blocksize + chipsize);
 	Serial.printf("PBA: %d, LBA: %d\n", pba, lba);
-	
+	#ifdef LATER	
 	uint8_t cmd[4];
 	cmd[0] = pba >> 8;
 	cmd[1] = pba;
@@ -1419,7 +1420,7 @@ uint8_t LittleFS_QPINAND::addBBLUT(uint32_t block_address)
 	
    //FLEXSPI2_LUT44 = LUT0(CMD_SDR, PINS1, 0xA1) | LUT0(WRITE_SDR, PINS1, 1);  
    //flexspi2_ip_write(8, 0x00800000, cmd, 4);
-	
+	#endif	
 	wait(progtime);
   }
 	return 0;

--- a/src/LittleFS_NAND.h
+++ b/src/LittleFS_NAND.h
@@ -77,7 +77,7 @@ public:
 	bool begin(uint8_t cspin, SPIClass &spiport=SPI);
 	uint8_t readECC(uint32_t address, uint8_t *data, int length);
 	void readBBLUT(uint16_t *LBA, uint16_t *PBA, uint8_t *linkStatus);
-	bool lowLevelFormat(char progressChar);
+	bool lowLevelFormat(char progressChar, Print* pr=&Serial);
 	uint8_t addBBLUT(uint32_t block_address);  //temporary for testing
   
 private:


### PR DESCRIPTION
If for example you are doing a display or the like, maybe you don't want the
32 dots to print on Serial, but maybe to your display.  So add optional parameter, to allow you to pass anything derived from class Print.
Defaults to Serial.

Also a few #ifdef LATER
in the NAND code for code that was setting up a command object but than not do anything with them.  This removed compiler warnings.

@mjs513 @Defragster - you might want to check if I missed anything.
I did run MTP with these changes and did to a format of a LittleFS RAM disk and the dots still showed up on debug window.