### PR TITLE
LittleFs supports the new format method

### DIFF
--- a/src/LittleFS.h
+++ b/src/LittleFS.h
@@ -241,6 +241,11 @@ public:
 		mounted = false;
 		config.context = nullptr;
 	}
+	virtual bool format(int type=0, char progressChar=0, Print& pr=Serial) {
+		if(type == 0) { return quickFormat(); }
+		if(type == 1) { return lowLevelFormat(progressChar, &pr); }
+		return true;
+	}
 	bool quickFormat();
 	bool lowLevelFormat(char progressChar=0, Print* pr=&Serial);
 	uint32_t formatUnused(uint32_t blockCnt, uint32_t blockStart);


### PR DESCRIPTION
@PaulStoffregen  and @mjs513  - Ok I synced up to new core changes and built using different names and parameter types, 
The format method will call
fastFormat when formatype=0
and lowlevelFormat if 1

So my MTP test builds again