### PR TITLE
RAM reset on any restart, cache flush not needed

### DIFF
--- a/src/LittleFS.h
+++ b/src/LittleFS.h
@@ -434,10 +434,6 @@ private:
 		return 0;
 	}
 	static int static_sync(const struct lfs_config *c) {
-		if ( c->context >= (void *)0x20200000 ) {
-			//Serial.printf("    arm_dcache_flush_delete: ptr=0x%x, size=%d\n", c->context, c->block_count * c->block_size);
-			arm_dcache_flush_delete(c->context, c->block_count * c->block_size );
-		}
 		return 0;
 	}
 };


### PR DESCRIPTION
the: arm_dcache_flush_delete()  covers ALL the cache over the entire DMA_MEM alloc for a RAM drive there. And serves no purpose if the MCU handles the cache, and the drive is always reset across ANY restart. This was only added to support warm start - and in any case should not have called for _delete preventing re-use.