### PR TITLE
LittleFs wrappers were missing the format members

### DIFF
--- a/src/LittleFS.h
+++ b/src/LittleFS.h
@@ -748,6 +748,7 @@ public:
   virtual bool rmdir(const char *filepath)  { return pfs->rmdir(filepath); }
   virtual uint64_t usedSize()  { return pfs->usedSize(); } 
   virtual uint64_t totalSize() { return pfs->totalSize(); }
+  virtual bool format(int type=0, char progressChar=0, Print& pr=Serial) { return pfs->format(type, progressChar, pr); }
 
 private:
   FS *pfs = &fsnone;
@@ -781,6 +782,7 @@ public:
   virtual bool rmdir(const char *filepath)  { return pfs->rmdir(filepath); }
   virtual uint64_t usedSize()  { return pfs->usedSize(); } 
   virtual uint64_t totalSize() { return pfs->totalSize();}
+  virtual bool format(int type=0, char progressChar=0, Print& pr=Serial) { return pfs->format(type, progressChar, pr); }
 private:
   FS *pfs = &fsnone;
   char display_name[10];


### PR DESCRIPTION
@PaulStoffregen  @mjs513
So they used default which is to return false.

Sorry I missed it before the release...